### PR TITLE
FIX 002 : doc[0]['unMeta'] returns KeyError: 0

### DIFF
--- a/pandoc_latex_tip.py
+++ b/pandoc_latex_tip.py
@@ -47,8 +47,16 @@ def toJSONFilters(actions):
         format = sys.argv[1]
     else:
         format = ""
+
+    if 'meta' in doc:
+        meta = doc['meta']
+    elif doc[0]:  # old API
+        meta = doc[0]['unMeta']
+    else:
+        meta = {}
+
     from functools import reduce
-    altered = reduce(lambda x, action: walk(x, action, format, doc[0]['unMeta']), actions, doc)
+    altered = reduce(lambda x, action: walk(x, action, format, meta), actions, doc)
     json.dump(altered, sys.stdout)
 
 def walk(x, action, format, meta):


### PR DESCRIPTION

the pandocfilters seems to handle a variation in the `doc` format 

see https://github.com/jgm/pandocfilters/blob/master/pandocfilters.py#L189

Applying the same text seems to fix the issue #2