### PR TITLE
FIX 003 : res = action(item['t'], item['c'].... returns KeyError: 'c'

### DIFF
--- a/pandoc_latex_tip.py
+++ b/pandoc_latex_tip.py
@@ -59,7 +59,7 @@ def walk(x, action, format, meta):
         array = []
         for item in x:
             if isinstance(item, dict) and 't' in item:
-                res = action(item['t'], item['c'], format, meta)
+                res = action(item['t'], item['c'] if 'c' in item else None, format, meta)
                 if res is None:
                     array.append(walk(item, action, format, meta))
                 elif isinstance(res, list):


### PR DESCRIPTION
The pandocfilters file checks is item['c'] exists like this:

see : https://github.com/jgm/pandocfilters/blob/master/pandocfilters.py#L111